### PR TITLE
Modified what seemed to be a bug in querystring get_model_and_key_from_relationship

### DIFF
--- a/anyblok_pyramid_rest_api/querystring.py
+++ b/anyblok_pyramid_rest_api/querystring.py
@@ -320,4 +320,4 @@ class QueryString:
 
             query = query.join(field, aliased=True, from_joinpoint=already_join)
             return self.get_model_and_key_from_relationship(
-                query, new_model, keys[1:], already_join=True)
+                query, new_model, keys[1:], already_join=already_join)

--- a/anyblok_pyramid_rest_api/tests/test_querystring.py
+++ b/anyblok_pyramid_rest_api/tests/test_querystring.py
@@ -37,6 +37,11 @@ def add_many2one_class():
         id = Integer(primary_key=True)
         test = Many2One(model=Declarations.Model.Test)
 
+    @Declarations.register(Declarations.Model)
+    class Test3:
+        id = Integer(primary_key=True)
+        test2 = Many2One(model=Declarations.Model.Test2)
+
 
 class MockRequestError:
 
@@ -603,3 +608,16 @@ class TestQueryStringWithM2O:
         waiting = ("'number' does not exist in model <class 'anyblok.model."
                    "factory.ModelTest'>.")
         assert res == waiting
+
+    def test_querystring_get_model_and_key_from_relationship_5(
+        self, registry_blok_with_m2o
+    ):
+        registry = registry_blok_with_m2o
+        request = MockRequest(self)
+        model = registry.Test3
+        query = model.query()
+        qs = QueryString(request, model)
+        res = qs.get_model_and_key_from_relationship(
+            query, model, ['test2', 'test', 'name'])
+        assert res[1] is registry.Test
+        assert res[2] == 'name'


### PR DESCRIPTION
It seemed like there was a bug with following more-than-one-level relationship, because of parameter already_join in function which was passed to True after second relationship level. This caused database to raise an exception on join because of parameter from_joinpoint set to True after second level relationship.